### PR TITLE
Potential fix for code scanning alert no. 14: SQL query built from user-controlled sources

### DIFF
--- a/lims/cli.py
+++ b/lims/cli.py
@@ -109,7 +109,10 @@ def resolve_container_id(conn, identifier: str) -> Optional[int]:
   identifier = (identifier or "").strip()
   key, value = parse_container_identifier(identifier)
 
-  row = conn.execute(f"SELECT id FROM containers WHERE {key} = ?", (value,)).fetchone()
+  if key == "id":
+    row = conn.execute("SELECT id FROM containers WHERE id = ?", (value,)).fetchone()
+  else:
+    row = conn.execute("SELECT id FROM containers WHERE barcode = ?", (value,)).fetchone()
   if not row and key == "id":
     # If numeric ID doesn't exist, treat original token as barcode.
     row = conn.execute("SELECT id FROM containers WHERE barcode = ?", (identifier,)).fetchone()


### PR DESCRIPTION
Potential fix for [https://github.com/chrisdudley-dev/nexus-lab-tracker/security/code-scanning/14](https://github.com/chrisdudley-dev/nexus-lab-tracker/security/code-scanning/14)

General approach: avoid including any user-controlled or tainted value directly in the SQL text. Instead, choose among fixed, hard-coded SQL statements based on validated state, and pass only data values as query parameters.

Best concrete fix here: change `resolve_container_id` so it does not interpolate `{key}` into the SQL. Since `parse_container_identifier` only ever returns `"id"` or `"barcode"`, we can branch explicitly:

- If `key == "id"`, run `SELECT id FROM containers WHERE id = ?`.
- Otherwise (i.e. `"barcode"`), run `SELECT id FROM containers WHERE barcode = ?`.

This keeps identical functionality (still supports lookup by numeric id or barcode, still falls back to treating an unknown numeric id as a barcode), but removes the dynamic SQL fragment. No new imports or helpers are needed, and all other codepaths, including the fallback query by barcode, remain unchanged.

Concretely:

- In `lims/cli.py`, in `resolve_container_id`, replace the single dynamic `conn.execute(f"SELECT id FROM containers WHERE {key} = ?", (value,))` call with an `if key == "id"` conditional that runs one of two hard-coded queries.

`resolve_sample_id` uses a similar pattern, but CodeQL’s current alerts are specifically about the container query. If you want to eliminate that future alert as well, you can apply the same pattern there; in this answer I only modify the code that CodeQL has reported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
