### PR TITLE
chore: envrc unset GH_TOKEN by default

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,3 +4,6 @@
 # - loads .env if present (local-only)
 # - sets defaults and exports
 source scripts/env.sh
+
+# Safety: prevent envrc from overriding gh auth
+unset GH_TOKEN


### PR DESCRIPTION
Prevent .envrc from overriding GitHub CLI auth by unsetting GH_TOKEN by default.