### PR TITLE
web: kanban send note field for status moves

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -181,7 +181,7 @@ async function renderBoard() {
             const r = await apiPost("/sample/status", {
               identifier: String(ident),
               status: String(to),
-              message: "kanban move"
+              note: "kanban move"
             });
             if (!(r.data && r.data.ok)) {
               setOutput("POST /sample/status (kanban)", r);


### PR DESCRIPTION
Kanban board uses 'note' (not 'message') when posting /sample/status to align with UI + API aliases.