### PR TITLE
chore: add /api alias for kanban board endpoint

### DIFF
--- a/lims/api_fastapi.py
+++ b/lims/api_fastapi.py
@@ -568,10 +568,12 @@ def _write_board(board: dict) -> None:
     tmp.write_text(json.dumps(board, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp.replace(path)
 
+@app.get("/api/kanban/board", response_model=KanbanBoardState)
 @app.get("/kanban/board", response_model=KanbanBoardState)
 def kanban_get_board():
     return _read_board()
 
+@app.put("/api/kanban/board", response_model=KanbanBoardState)
 @app.put("/kanban/board", response_model=KanbanBoardState)
 def kanban_put_board(state: KanbanBoardState):
     if not state.columnOrder:


### PR DESCRIPTION
Adds /api/kanban/board aliases for existing /kanban/board GET/PUT so callers using the standard /api/* prefix work.