### PR TITLE
Document container workflow API contract

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -95,16 +95,84 @@ Response (200): Content-Type application/gzip
 
 ---
 
-## Planned workflow endpoints (next)
+## Container workflow endpoints
 
 ### POST /container/add
-Request:
-{ "barcode": "TUBE-1", "kind": "tube", "location": "bench-A" }
+Create a container record for downstream sample assignment and workflow tracking.
 
-Response (200): schema nexus_container (v1)
+Request (JSON):
+
+{
+  "barcode": "TUBE-1",
+  "kind": "tube",
+  "location": "bench-A"
+}
+
+Fields:
+- `barcode` (string, required) - unique container barcode / identifier.
+- `kind` (string, required) - container type, such as `tube`.
+- `location` (string, optional) - free-text location label.
+
+Response (200):
+
+{
+  "schema": "nexus_container",
+  "schema_version": 1,
+  "ok": true,
+  "container": {
+    "id": 123,
+    "barcode": "TUBE-1",
+    "kind": "tube",
+    "location": "bench-A",
+    "created_at": "2026-02-05T20:00:00Z",
+    "updated_at": "2026-02-05T20:00:00Z"
+  }
+}
+
+Errors:
+- `400 bad_request` for missing fields, malformed JSON, invalid text values, or other validation failures.
+- `400 bad_request` for duplicate barcodes, with a descriptive detail string.
+- `500 internal_error` if the container store is unavailable or the containers table cannot be used.
+
+Safety notes:
+- Container identifiers are validated before persistence.
+- Path-like or traversal-style values are rejected rather than interpreted as filesystem paths.
+- `location` is treated as plain text metadata only; the server does not use client-supplied directories for container creation.
 
 ### GET /container/list?limit=25
-Response (200): schema nexus_container_list (v1)
+List recently created containers, newest first.
+
+Query params:
+- `limit` (integer, optional, default `25`, max `500`) - number of containers to return.
+
+Response (200):
+
+{
+  "schema": "nexus_container_list",
+  "schema_version": 1,
+  "ok": true,
+  "limit": 25,
+  "count": 1,
+  "containers": [
+    {
+      "id": 123,
+      "barcode": "TUBE-1",
+      "kind": "tube",
+      "location": "bench-A",
+      "created_at": "2026-02-05T20:00:00Z",
+      "updated_at": "2026-02-05T20:00:00Z"
+    }
+  ]
+}
+
+Stable response fields:
+- `limit` echoes the effective server-applied limit after validation and clamping.
+- `count` reports the number of returned containers.
+- `containers` is an array of container objects ordered by descending `id`.
+
+Errors:
+- `400 bad_request` if `limit` is not an integer or is negative.
+- `500 internal_error` if the container store is unavailable or the containers table cannot be used.
 
 ## POST /sample/add
 


### PR DESCRIPTION
## Summary

The container workflow was still described as upcoming even though the HTTP handlers and regressions already existed. I updated the API contract to treat `POST /container/add` and `GET /container/list` as stable endpoints, documenting their request fields, returned schemas, validation and duplicate handling, and the safety expectations for client-supplied values.

## Changes

- Replaced the planned container section with stable API contract entries for `POST /container/add` and `GET /container/list`.
- Documented the container add request fields, success envelope, duplicate/invalid-input behavior, and safety notes for path-like values.
- Documented the list endpoint's `limit` query parameter, effective limit clamping, and stable response fields: `limit`, `count`, and `containers`.

## Verification

- **PASS — contract text check:** `docs/API_CONTRACT.md` no longer contains the planned label for container endpoints.
- **PASS — diff hygiene check:** `git diff --check -- docs/API_CONTRACT.md` reported no whitespace or patch-format issues.
- **PASS — focused text assertion:** A direct content check confirmed the container endpoints are present and the planned section is gone.