### PR TITLE
Default demo API client to the frontend proxy

### DIFF
--- a/frontend/src/lib/api/client.js
+++ b/frontend/src/lib/api/client.js
@@ -1,8 +1,8 @@
 // Minimal API client for the demo UI.
-// - Base URL comes from VITE_API_BASE (or defaults to same-origin).
+// - Base URL comes from VITE_API_BASE (or defaults to the frontend proxy).
 // - Guest session token is stored in localStorage and sent as a header.
 
-const DEFAULT_BASE = ""; // same-origin by default
+const DEFAULT_BASE = "/api";
 
 function getBaseUrl() {
   return (import.meta?.env?.VITE_API_BASE ?? DEFAULT_BASE).replace(/\/+$/, "");


### PR DESCRIPTION
## Summary

The sample API client was defaulting to same-origin requests, which bypassed the frontend proxy; it now defaults to `/api` while still honoring `VITE_API_BASE` and trimming trailing slashes, so demo calls route through the proxy by default.

## Changes

- Changed the API client default base path from same-origin to `/api`
- Preserved `VITE_API_BASE` override handling and trailing-slash trimming
- Kept session header behavior unchanged

## Verification

- **PASS — Default URL composition check:** Resolved sample endpoints to `/api/health`, `/api/auth/guest`, `/api/sample/list`, and `/api/sample/status`
- **SKIPPED — Frontend build:** Build could not run because frontend dependencies were not installed in the workspace