### PR TITLE
Use the module timestamp helper for sample status events

### DIFF
--- a/lims/api_sample_status.py
+++ b/lims/api_sample_status.py
@@ -119,7 +119,7 @@ def _insert_sample_event(
         cols = [r[1] for r in info]  # (cid, name, type, notnull, dflt, pk)
         colset = set(cols)
 
-        ts = now_iso()
+        ts = _now_iso()
         payload: dict[str, object] = {}
 
         # Core identifiers


### PR DESCRIPTION
## Summary

Sample status event writes were failing because the event helper called an undefined timestamp name, which caused the insert path to fall back without recording the event; the helper now uses the module’s existing UTC timestamp function so status changes can persist `status_changed` events with timestamps and notes.

## Changes

- Replaced the undefined timestamp call in the sample event insert helper with the module’s UTC timestamp helper.
- Preserved the existing `/sample/status` response shape, including `schema`, `schema_version`, `ok`, `from_status`, `to_status`, `sample`, and `event_recorded`.
- Verified the helper can now insert a `status_changed` row into `sample_events` when the table exists.

## Verification

- **PASS — Python compile check:** `python3 -m py_compile lims/api_sample_status.py` completed successfully.
- **PASS — Socket-free helper regression:** In-memory SQLite regression returned `True` and inserted exactly one `sample_events` row with the expected note and timestamp.
- **PASS — Core regression gate:** Repository core regressions completed successfully before the API socket-limited portion of the script.
- **SKIPPED — API socket regression:** The first socket-creating API regression was blocked by the sandbox with `PermissionError: Operation not permitted`.