### PR TITLE
Render explicit demo API health states

### DIFF
--- a/frontend/src/lib/ui.css
+++ b/frontend/src/lib/ui.css
@@ -46,10 +46,143 @@
   overflow-x:auto; line-height:1.35;
 }
 
+.healthToolbar{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  align-items:center;
+  margin-bottom:12px;
+}
+.healthStatusCard{
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:18px;
+  background: linear-gradient(180deg, rgba(255,255,255,.96), rgba(248,250,252,.98));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, .05);
+}
+.healthStatusCardLoading{
+  border-color:#cbd5e1;
+}
+.healthStatusCardHealthy{
+  border-color:#86efac;
+  background: linear-gradient(180deg, rgba(236,253,245,.98), rgba(255,255,255,.98));
+}
+.healthStatusCardUnhealthy{
+  border-color:#fbbf24;
+  background: linear-gradient(180deg, rgba(255,251,235,.98), rgba(255,255,255,.98));
+}
+.healthStatusCardError{
+  border-color:#fca5a5;
+  background: linear-gradient(180deg, rgba(254,242,242,.98), rgba(255,255,255,.98));
+}
+.healthStatusCardEmpty{
+  border-style:dashed;
+}
+.healthStatusHeader{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:16px;
+  margin-bottom:16px;
+  flex-wrap:wrap;
+}
+.healthStatusTitle{
+  font-size:1.1rem;
+  font-weight:700;
+  margin-bottom:4px;
+}
+.healthStatusCopy{
+  color:var(--muted);
+  line-height:1.5;
+  max-width: 60ch;
+}
+.healthStatusPill{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:6px 10px;
+  border-radius:999px;
+  border:1px solid var(--border);
+  background:#fff;
+  font-size:.82rem;
+  font-weight:700;
+  white-space:nowrap;
+}
+.healthStatusPillEmpty,
+.healthStatusPillLoading{
+  color:#334155;
+}
+.healthStatusPillHealthy{
+  border-color:#86efac;
+  background:#dcfce7;
+  color:#166534;
+}
+.healthStatusPillUnhealthy{
+  border-color:#fbbf24;
+  background:#fef3c7;
+  color:#92400e;
+}
+.healthStatusPillError{
+  border-color:#fca5a5;
+  background:#fee2e2;
+  color:#991b1b;
+}
+.healthDetailsGrid{
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap:12px;
+  margin:16px 0;
+}
+.healthDetail{
+  padding:12px 14px;
+  border:1px solid rgba(148,163,184,.35);
+  border-radius:12px;
+  background: rgba(255,255,255,.82);
+}
+.healthDetailLabel{
+  font-size:.78rem;
+  text-transform:uppercase;
+  letter-spacing:.06em;
+  color:var(--muted);
+  margin-bottom:6px;
+}
+.healthDetailValue{
+  font-weight:600;
+  word-break:break-word;
+  line-height:1.45;
+}
+.healthEmptyState{
+  border:1px dashed rgba(148,163,184,.55);
+  border-radius:14px;
+  padding:16px;
+  background: rgba(255,255,255,.75);
+}
+.healthEmptyTitle{
+  font-weight:700;
+  margin-bottom:6px;
+}
+.healthEmptyCopy{
+  margin:0;
+  color:var(--muted);
+  line-height:1.5;
+}
+.healthPayload{
+  background:#0f172a;
+  color:#e2e8f0;
+  padding:16px;
+  border-radius:12px;
+  overflow-x:auto;
+  line-height:1.45;
+  margin:16px 0 0;
+}
+
 /* Responsive baseline */
 @media (max-width: 640px){
   :root{ --pad: 16px; }
   .headerRow{ flex-direction: column; align-items: flex-start; }
   .nav{ width: 100%; }
   .navLink{ padding: 10px 12px; }
+  .healthStatusHeader{
+    flex-direction:column;
+  }
 }

--- a/frontend/src/pages/Demo.jsx
+++ b/frontend/src/pages/Demo.jsx
@@ -1,29 +1,147 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import SamplesPanel from '../SamplesPanel.jsx'
 import KanbanApp from '../components/kanban/KanbanApp.jsx'
 
-export default function Demo() {
-  const [tab, setTab] = useState('samples')
-  const [health, setHealth] = useState(null)
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState(null)
+const HEALTH_PHASE = {
+  empty: 'empty',
+  loading: 'loading',
+  healthy: 'healthy',
+  unhealthy: 'unhealthy',
+  error: 'error',
+}
 
-  async function loadHealth() {
-    setLoading(true); setErr(null)
-    try {
-      const r = await fetch('/api/health', { headers: { Accept: 'application/json' } })
-      const j = await r.json().catch(async () => ({ raw: await r.text() }))
-      if (!r.ok) throw new Error(`HTTP ${r.status}: ${JSON.stringify(j).slice(0, 300)}`)
-      setHealth(j)
-    } catch (e) {
-      setErr(String(e?.message || e))
-      setHealth(null)
-    } finally {
-      setLoading(false)
-    }
+function readHealthLabel(phase) {
+  switch (phase) {
+    case HEALTH_PHASE.loading:
+      return 'Loading health check'
+    case HEALTH_PHASE.healthy:
+      return 'API reachable and healthy'
+    case HEALTH_PHASE.unhealthy:
+      return 'API reachable but unhealthy'
+    case HEALTH_PHASE.error:
+      return 'Health request failed'
+    default:
+      return 'No health data yet'
+  }
+}
+
+function formatHealthValue(value) {
+  if (value === null || value === undefined || value === '') {
+    return 'Not provided'
   }
 
-  useEffect(() => { loadHealth() }, [])
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+function readDetailFromResponse(body, status) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return `HTTP ${status}`
+  }
+
+  if (typeof body.detail === 'string' && body.detail.trim()) {
+    return `HTTP ${status}: ${body.detail}`
+  }
+
+  if (typeof body.error === 'string' && body.error.trim()) {
+    return `HTTP ${status}: ${body.error}`
+  }
+
+  return `HTTP ${status}`
+}
+
+function isHealthPayload(body) {
+  return Boolean(body && typeof body === 'object' && !Array.isArray(body) && body.schema === 'nexus_api_health')
+}
+
+function hasDocumentedHealthShape(body) {
+  return isHealthPayload(body) && typeof body.schema_version === 'number' && typeof body.ok === 'boolean'
+}
+
+function getHealthStateClasses(phase) {
+  switch (phase) {
+    case HEALTH_PHASE.healthy:
+      return 'healthStatusCard healthStatusCardHealthy'
+    case HEALTH_PHASE.unhealthy:
+      return 'healthStatusCard healthStatusCardUnhealthy'
+    case HEALTH_PHASE.error:
+      return 'healthStatusCard healthStatusCardError'
+    case HEALTH_PHASE.loading:
+      return 'healthStatusCard healthStatusCardLoading'
+    default:
+      return 'healthStatusCard healthStatusCardEmpty'
+  }
+}
+
+export default function Demo() {
+  const [tab, setTab] = useState('samples')
+  const [healthState, setHealthState] = useState({
+    phase: HEALTH_PHASE.empty,
+    data: null,
+    error: null,
+  })
+
+  const loadHealth = useCallback(async () => {
+    setHealthState({
+      phase: HEALTH_PHASE.loading,
+      data: null,
+      error: null,
+    })
+
+    try {
+      const r = await fetch('/api/health', { headers: { Accept: 'application/json' } })
+      const rawBody = await r.text()
+      const body = rawBody.trim() ? JSON.parse(rawBody) : null
+
+      if (!r.ok) {
+        throw new Error(readDetailFromResponse(body, r.status))
+      }
+
+      if (!body || !Object.keys(body).length) {
+        setHealthState({
+          phase: HEALTH_PHASE.empty,
+          data: null,
+          error: null,
+        })
+        return
+      }
+
+      if (!hasDocumentedHealthShape(body)) {
+        throw new Error('Unexpected response shape from /api/health')
+      }
+
+      setHealthState({
+        phase: body.ok ? HEALTH_PHASE.healthy : HEALTH_PHASE.unhealthy,
+        data: body,
+        error: null,
+      })
+    } catch (e) {
+      setHealthState({
+        phase: HEALTH_PHASE.error,
+        data: null,
+        error: String(e?.message || e),
+      })
+    }
+  }, [])
+
+  useEffect(() => { void loadHealth() }, [loadHealth])
+
+  const { phase, data, error } = healthState
+  const statusLabel = readHealthLabel(phase)
+  const isBusy = phase === HEALTH_PHASE.loading
+  const showPayload = phase === HEALTH_PHASE.healthy || phase === HEALTH_PHASE.unhealthy
+  const refreshLabel = isBusy ? 'Refreshing...' : phase === HEALTH_PHASE.empty ? 'Load Health' : 'Refresh Health'
+  const schemaVersion = data?.schema_version
+  const healthDetails = [
+    ['Schema', data?.schema],
+    ['Schema version', schemaVersion === undefined || schemaVersion === null ? null : schemaVersion],
+    ['ok', data?.ok === undefined ? null : String(data.ok)],
+    ['Git revision', data?.git_rev],
+    ['Database path', data?.db_path],
+  ].filter(([, value]) => value !== null && value !== undefined)
 
   return (
     <div>
@@ -40,9 +158,9 @@ export default function Demo() {
           Health
         </button>
 
-        {loading ? <span style={{ opacity: 0.8 }}>Loading…</span> : null}
-        {err ? <span style={{ color: 'crimson' }}>Error: {err}</span> : null}
-        {health?.ok ? <span style={{ color: 'green' }}>API OK</span> : null}
+        <span className={`healthStatusPill healthStatusPill${phase[0].toUpperCase()}${phase.slice(1)}`}>
+          {statusLabel}
+        </span>
       </div>
 
       {tab === 'samples' ? (
@@ -51,14 +169,69 @@ export default function Demo() {
         <KanbanApp />
       ) : (
         <div>
-          <div style={{ display: 'flex', gap: 10, alignItems: 'center', marginBottom: 12 }}>
-            <button onClick={loadHealth} disabled={loading} style={{ padding: '8px 12px', borderRadius: 10 }}>
-              Refresh Health
+          <div className="healthToolbar">
+            <button onClick={loadHealth} disabled={isBusy} style={{ padding: '8px 12px', borderRadius: 10 }}>
+              {refreshLabel}
             </button>
+            <span className="muted">The demo reads the documented `/api/health` response shape.</span>
           </div>
-          <pre style={{ background: '#111', color: '#eee', padding: 16, borderRadius: 10, overflowX: 'auto', lineHeight: 1.35 }}>
-            {health ? JSON.stringify(health, null, 2) : 'No data'}
-          </pre>
+
+          <section className={getHealthStateClasses(phase)} aria-live="polite" aria-busy={isBusy}>
+            <div className="healthStatusHeader">
+              <div>
+                <div className="healthStatusTitle">{statusLabel}</div>
+                <div className="healthStatusCopy">
+                  {phase === HEALTH_PHASE.loading ? 'Fetching /api/health now.' : null}
+                  {phase === HEALTH_PHASE.healthy ? 'The backend returned the documented health payload with ok=true.' : null}
+                  {phase === HEALTH_PHASE.unhealthy ? 'The backend returned the documented health payload with ok=false.' : null}
+                  {phase === HEALTH_PHASE.error ? error : null}
+                  {phase === HEALTH_PHASE.empty ? 'No health payload has been loaded yet. Use Refresh Health to query the endpoint.' : null}
+                </div>
+              </div>
+              <div className={`healthStatusPill healthStatusPill${phase[0].toUpperCase()}${phase.slice(1)}`}>
+                {statusLabel}
+              </div>
+            </div>
+
+            {phase === HEALTH_PHASE.empty ? (
+              <div className="healthEmptyState">
+                <div className="healthEmptyTitle">No data loaded</div>
+                <p className="healthEmptyCopy">
+                  The demo has not yet received a health payload. Refresh the endpoint to check whether the API is
+                  reachable and whether `ok` is true.
+                </p>
+              </div>
+            ) : null}
+
+            {phase === HEALTH_PHASE.loading ? (
+              <div className="healthEmptyState">
+                <div className="healthEmptyTitle">Loading</div>
+                <p className="healthEmptyCopy">Waiting for `/api/health` to respond.</p>
+              </div>
+            ) : null}
+
+            {phase === HEALTH_PHASE.error ? (
+              <div className="healthEmptyState">
+                <div className="healthEmptyTitle">Request error</div>
+                <p className="healthEmptyCopy">{error}</p>
+              </div>
+            ) : null}
+
+            {showPayload ? (
+              <div className="healthDetailsGrid">
+                {healthDetails.map(([label, value]) => (
+                  <div className="healthDetail" key={label}>
+                    <div className="healthDetailLabel">{label}</div>
+                    <div className="healthDetailValue">{formatHealthValue(value)}</div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {showPayload ? (
+              <pre className="healthPayload">{JSON.stringify(data, null, 2)}</pre>
+            ) : null}
+          </section>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

The demo health panel now distinguishes loading, empty, healthy, unhealthy, and request-error outcomes from `/api/health`, and it surfaces the documented schema details plus revision metadata when the health payload is present.

## Changes

- Replaced the demo health fetch with explicit phase tracking so refreshes clear stale success or error state and classify empty, healthy, unhealthy, and error outcomes separately.
- Added a structured health card that shows schema, schema version, ok, git revision, database path, and the raw JSON payload when the documented health shape is returned.
- Added shared UI styles for the new health status card, badges, detail grid, and empty/error/loading states.

## Verification

- **PASS — Frontend dependencies install:** `npm ci` completed successfully in `frontend`.
- **PASS — Focused ESLint:** `node ./node_modules/eslint/bin/eslint.js src/pages/Demo.jsx src/components/Layout.jsx --report-unused-disable-directives --max-warnings 0` exited 0.
- **PASS — Production build:** `npm run build` completed successfully with a production Vite bundle.
- **PASS — Whitespace diff check:** `git diff --check` exited 0 with no whitespace errors.