### PR TITLE
Contain Kanban overflow and improve mobile controls

### DIFF
--- a/frontend/src/components/kanban/KanbanApp.jsx
+++ b/frontend/src/components/kanban/KanbanApp.jsx
@@ -1,5 +1,12 @@
 import { useReducer, useState, useEffect } from 'react'
-import { DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCorners } from '@dnd-kit/core'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import KanbanBoard from './KanbanBoard.jsx'
 import { createInitialState, reducer } from '../../lib/kanban/model.js'
@@ -14,7 +21,7 @@ function Inspector({ card, ioErr, onSave, onDelete, onClose }) {
   }, [card?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div style={{ border: '1px solid #e5e7eb', borderRadius: 12, padding: 12 }}>
+    <div className="kanbanInspector">
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10, alignItems: 'baseline', marginBottom: 10 }}>
         <div style={{ fontWeight: 700 }}>Inspector</div>
         {card ? <button onClick={onClose} className="btn">Close</button> : null}
@@ -83,8 +90,12 @@ export default function KanbanApp() {
   }, [state])
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
   )
 
   const selected = state.selectedCardId ? state.cards[state.selectedCardId] : null
@@ -179,30 +190,32 @@ export default function KanbanApp() {
   }
 
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: '1fr minmax(240px, 320px)', gap: 12, alignItems: 'start' }}>
-      <div>
-        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center', marginBottom: 12 }}>
+    <div className="kanbanWorkspace">
+      <div className="kanbanWorkspaceMain">
+        <div className="kanbanToolbar">
           <button onClick={addCard} className="btn btnPrimary">Add card</button>
           <button onClick={resetBoard} className="btn">Reset board</button>
           <button onClick={exportBoard} className="btn">Export JSON</button>
           <button onClick={importBoard} className="btn">Import JSON</button>
-          <div style={{ opacity: 0.75, fontSize: 13 }}>
+          <div className="kanbanToolbarCopy">
             Drag cards between columns • Click to edit in Inspector
           </div>
         </div>
 
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCorners}
-          onDragEnd={onDragEnd}
-        >
-          <KanbanBoard
-            columnOrder={state.columnOrder}
-            columnsById={state.columns}
-            cardsById={state.cards}
-            onCardClick={(c) => dispatch({ type: 'select', cardId: c.id })}
-          />
-        </DndContext>
+        <div className="kanbanBoardShell">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCorners}
+            onDragEnd={onDragEnd}
+          >
+            <KanbanBoard
+              columnOrder={state.columnOrder}
+              columnsById={state.columns}
+              cardsById={state.cards}
+              onCardClick={(c) => dispatch({ type: 'select', cardId: c.id })}
+            />
+          </DndContext>
+        </div>
       </div>
 
       <Inspector ioErr={ioErr}

--- a/frontend/src/components/kanban/KanbanBoard.jsx
+++ b/frontend/src/components/kanban/KanbanBoard.jsx
@@ -2,7 +2,10 @@ import KanbanColumn from './KanbanColumn.jsx'
 
 export default function KanbanBoard({ columnOrder, columnsById, cardsById, onCardClick }) {
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: `repeat(${columnOrder.length}, minmax(220px, 1fr))`, gap: 12 }}>
+    <div
+      className="kanbanBoard"
+      style={{ gridTemplateColumns: `repeat(${columnOrder.length}, minmax(220px, clamp(220px, 24vw, 280px)))` }}
+    >
       {columnOrder.map((colId) => (
         <KanbanColumn
           key={colId}

--- a/frontend/src/components/kanban/KanbanCard.jsx
+++ b/frontend/src/components/kanban/KanbanCard.jsx
@@ -2,32 +2,74 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 
 export default function KanbanCard({ card, onClick }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: card.id })
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: card.id })
 
-  const style = {
+  const cardStyle = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.7 : 1,
-    textAlign: 'left',
     width: '100%',
+    boxSizing: 'border-box',
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
+    gap: 8,
+    alignItems: 'start',
     borderRadius: 12,
-    padding: 12,
+    padding: 8,
     background: '#fff',
     border: '1px solid #e5e7eb',
+  }
+
+  const editStyle = {
+    minWidth: 0,
+    padding: 4,
+    border: 0,
+    background: 'transparent',
+    textAlign: 'left',
+    cursor: 'pointer',
+  }
+
+  const handleStyle = {
+    padding: '4px 7px',
+    border: '1px solid #d1d5db',
+    borderRadius: 8,
+    background: '#fff',
     cursor: 'grab',
+    lineHeight: 1,
   }
 
   return (
-    <button
-      ref={setNodeRef}
-      type="button"
-      onClick={onClick}
-      style={style}
-      {...attributes}
-      {...listeners}
-    >
-      <div style={{ fontWeight: 650, marginBottom: 6 }}>{card.title}</div>
-      {card.subtitle ? <div style={{ opacity: 0.75, fontSize: 13 }}>{card.subtitle}</div> : null}
-    </button>
+    <div ref={setNodeRef} style={cardStyle}>
+      <button
+        type="button"
+        onClick={onClick}
+        style={editStyle}
+      >
+        <div style={{ fontWeight: 650, marginBottom: 6 }}>{card.title}</div>
+        {card.subtitle ? (
+          <div style={{ opacity: 0.75, fontSize: 13 }}>{card.subtitle}</div>
+        ) : null}
+      </button>
+
+      <button
+        ref={setActivatorNodeRef}
+        type="button"
+        aria-label={`Move ${card.title}`}
+        title="Drag or use the keyboard to move this card"
+        style={handleStyle}
+        {...attributes}
+        {...listeners}
+      >
+        <span aria-hidden="true">⋮⋮</span>
+      </button>
+    </div>
   )
 }

--- a/frontend/src/lib/ui.css
+++ b/frontend/src/lib/ui.css
@@ -46,6 +46,55 @@
   overflow-x:auto; line-height:1.35;
 }
 
+.kanbanWorkspace{
+  display:grid;
+  grid-template-columns:minmax(0, 1fr) minmax(240px, 320px);
+  gap:12px;
+  align-items:start;
+  min-width:0;
+}
+.kanbanWorkspaceMain{
+  min-width:0;
+  display:grid;
+  gap:12px;
+}
+.kanbanToolbar{
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+  align-items:center;
+  min-width:0;
+}
+.kanbanToolbarCopy{
+  opacity:0.75;
+  font-size:13px;
+  min-width:0;
+  overflow-wrap:anywhere;
+}
+.kanbanBoardShell{
+  min-width:0;
+  max-width:100%;
+  overflow-x:auto;
+  overflow-y:hidden;
+  overscroll-behavior-x:contain;
+  -webkit-overflow-scrolling:touch;
+  padding-bottom:4px;
+}
+.kanbanBoard{
+  display:grid;
+  gap:12px;
+  width:max-content;
+  min-width:100%;
+}
+.kanbanInspector{
+  min-width:0;
+  width:100%;
+  border:1px solid #e5e7eb;
+  border-radius:12px;
+  padding:12px;
+  box-sizing:border-box;
+}
+
 .healthToolbar{
   display:flex;
   gap:12px;
@@ -184,5 +233,14 @@
   .navLink{ padding: 10px 12px; }
   .healthStatusHeader{
     flex-direction:column;
+  }
+}
+
+@media (max-width: 900px){
+  .kanbanWorkspace{
+    grid-template-columns:1fr;
+  }
+  .kanbanBoardShell{
+    margin-right:0;
   }
 }


### PR DESCRIPTION
## Summary
- Stack the Inspector below the Kanban board on narrow screens.
- Constrain horizontal overflow to the board scroller.
- Wrap toolbar controls on smaller viewports.
- Separate card editing from drag activation with an accessible drag handle.

## Verification
- `npm run lint`
- `npm run build`
- Responsive checks at 320, 375, 390, 768, and 1280 px
- Touch activation at 390 px
- Keyboard Tab focus, visible focus, and Enter activation at 390 px
- `git diff --check`
