### PR TITLE
Support long-press card dragging on touch

### DIFF
--- a/frontend/src/components/kanban/KanbanApp.jsx
+++ b/frontend/src/components/kanban/KanbanApp.jsx
@@ -2,7 +2,8 @@ import { useReducer, useState, useEffect } from 'react'
 import {
   DndContext,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCorners,
   useSensor,
   useSensors,
@@ -90,8 +91,14 @@ export default function KanbanApp() {
   }, [state])
 
   const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 6 },
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 8,
+      },
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
@@ -198,7 +205,7 @@ export default function KanbanApp() {
           <button onClick={exportBoard} className="btn">Export JSON</button>
           <button onClick={importBoard} className="btn">Import JSON</button>
           <div className="kanbanToolbarCopy">
-            Drag cards between columns • Click to edit in Inspector
+            Hold and drag on touch • Tap or click to edit
           </div>
         </div>
 

--- a/frontend/src/components/kanban/KanbanCard.jsx
+++ b/frontend/src/components/kanban/KanbanCard.jsx
@@ -35,6 +35,9 @@ export default function KanbanCard({ card, onClick }) {
     background: 'transparent',
     textAlign: 'left',
     cursor: 'pointer',
+    touchAction: 'manipulation',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
   }
 
   const handleStyle = {
@@ -44,14 +47,27 @@ export default function KanbanCard({ card, onClick }) {
     background: '#fff',
     cursor: 'grab',
     lineHeight: 1,
+    minWidth: 44,
+    minHeight: 44,
+    display: 'grid',
+    placeItems: 'center',
+    touchAction: 'manipulation',
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
   }
+
+  const bodyTouchListeners = listeners?.onTouchStart
+    ? { onTouchStart: listeners.onTouchStart }
+    : {}
 
   return (
     <div ref={setNodeRef} style={cardStyle}>
       <button
         type="button"
+        title="Tap to edit. Hold and drag to move."
         onClick={onClick}
         style={editStyle}
+        {...bodyTouchListeners}
       >
         <div style={{ fontWeight: 650, marginBottom: 6 }}>{card.title}</div>
         {card.subtitle ? (


### PR DESCRIPTION
## Summary
- Support press-and-hold dragging from anywhere on a card on touch devices.
- Preserve quick tap or click behavior for opening the Inspector.
- Use separate mouse, touch, and keyboard drag sensors.
- Enlarge the dedicated drag handle to a 44 px touch target.

## Verification
- `npm run lint`
- `npm run build`
- Physical Android verification required before merge
